### PR TITLE
fix: term expansion alignment

### DIFF
--- a/vc/authorization-credential-v1.jsonld
+++ b/vc/authorization-credential-v1.jsonld
@@ -24,8 +24,8 @@
          "@id":"ex:issuerDIDDoc",
          "@type":"DIDDoc"
       },
-      "rpDIDDoc":{
-         "@id":"ex:rpDIDDoc",
+      "requestingPartyDIDDoc":{
+         "@id":"ex:requestingPartyDIDDoc",
          "@type":"DIDDoc"
       },
       "subjectDID":{


### PR DESCRIPTION
Expanding `rpDIDDoc` -> `relyingPartyDIDDoc` to align with the other terms.

Signed-off-by: George Aristy <george.aristy@securekey.com>